### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.4
+  - 2.4.1
 
+before_install:
+  - gem update bundler
 services:
   - memcached

--- a/fluent-plugin-memcached.gemspec
+++ b/fluent-plugin-memcached.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_runtime_dependency "dalli"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit"

--- a/lib/fluent/plugin/out_memcached.rb
+++ b/lib/fluent/plugin/out_memcached.rb
@@ -1,3 +1,4 @@
+require 'dalli'
 require 'fluent/plugin/output'
 
 class Fluent::Plugin::MemcachedOutput < Fluent::Plugin::Output
@@ -17,7 +18,6 @@ class Fluent::Plugin::MemcachedOutput < Fluent::Plugin::Output
 
   def initialize
     super
-    require 'dalli'
   end
 
   def configure(conf)

--- a/lib/fluent/plugin/out_memcached.rb
+++ b/lib/fluent/plugin/out_memcached.rb
@@ -1,4 +1,6 @@
-class Fluent::MemcachedOutput < Fluent::BufferedOutput
+require 'fluent/plugin/output'
+
+class Fluent::Plugin::MemcachedOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('memcached', self)
 
   config_param :host, :string, :default => 'localhost'
@@ -33,10 +35,19 @@ class Fluent::MemcachedOutput < Fluent::BufferedOutput
 
   def shutdown
     @memcached.close
+    super
   end
 
   def format(tag, time, record)
     [tag, time, record].to_msgpack
+  end
+
+  def formatted_to_msgpack_binary?
+    true
+  end
+
+  def multi_workers_ready?
+    true
   end
 
   def write(chunk)

--- a/lib/fluent/plugin/out_memcached.rb
+++ b/lib/fluent/plugin/out_memcached.rb
@@ -16,10 +16,6 @@ class Fluent::Plugin::MemcachedOutput < Fluent::Plugin::Output
   attr_accessor :memcached
   attr_accessor :formatter
 
-  def initialize
-    super
-  end
-
   def configure(conf)
     super
     if @value_format == 'json' and @param_names.nil?

--- a/test/plugin/test_out_memcached.rb
+++ b/test/plugin/test_out_memcached.rb
@@ -115,22 +115,28 @@ class MemcachedOutputTest < Test::Unit::TestCase
     assert_equal record2_value_json, d.instance.memcached.get('d')
   end
 
-  def test_write_increment
-    d = create_driver(CONFIG_INCREMENT)
-    time = event_time('2011-01-02 13:14:15 UTC')
-    record1 = {'key' => 'count1', 'param1' => 1}
-    record2 = {'key' => 'count2', 'param1' => 2}
-    record3 = {'key' => 'count1', 'param1' => 3}
-    record4 = {'key' => 'count2', 'param1' => 4}
-    d.run(default_tag: 'test') do
-      d.feed(time, record1)
-      d.feed(time, record2)
-      d.feed(time, record3)
-      d.feed(time, record4)
+  class IncrementTest < self
+    def teardown
+      @d.instance.memcached.flush_all
     end
 
-    assert_equal (1 + 3), d.instance.memcached.get('count1').to_i
-    assert_equal (2 + 4), d.instance.memcached.get('count2').to_i
+    def test_write_increment
+      @d = create_driver(CONFIG_INCREMENT)
+      time = event_time('2011-01-02 13:14:15 UTC')
+      record1 = {'key' => 'count1', 'param1' => 1}
+      record2 = {'key' => 'count2', 'param1' => 2}
+      record3 = {'key' => 'count1', 'param1' => 3}
+      record4 = {'key' => 'count2', 'param1' => 4}
+      @d.run(default_tag: 'test') do
+        @d.feed(time, record1)
+        @d.feed(time, record2)
+        @d.feed(time, record3)
+        @d.feed(time, record4)
+      end
+
+      assert_equal (1 + 3), @d.instance.memcached.get('count1').to_i
+      assert_equal (2 + 4), @d.instance.memcached.get('count2').to_i
+    end
   end
 
   def test_write_to_mysql


### PR DESCRIPTION
I've tried to use v0.14 Output plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,