### PR TITLE
Add documents for v0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Default values would look like this:
 
 ```
 <match dummy>
-  type memcached
+  @type memcached
   host localhost
   port 11211
   increment false
@@ -39,7 +39,7 @@ To store values as json, like this:
 
 ```
 <match dummy>
-  type memcached
+  @type memcached
   host localhost
   port 11211
   value_format json
@@ -55,7 +55,7 @@ When using v0.14 style configuration, you can choose three different type of buf
 
 ```
 <match dummy>
-  type memcached
+  @type memcached
   host localhost
   port 11211
   increment false
@@ -70,7 +70,7 @@ When using v0.14 style configuration, you can choose three different type of buf
 
 ```
 <match dummy>
-  type memcached
+  @type memcached
   host localhost
   port 11211
   increment false
@@ -85,7 +85,7 @@ When using v0.14 style configuration, you can choose three different type of buf
 
 ```
 <match dummy>
-  type memcached
+  @type memcached
   host localhost
   port 11211
   increment false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 
 Send your logs to Memcached.
 
+## Requirements
+
+| fluent-plugin-memcached | fluentd | ruby |
+|------------------------|---------|------|
+| >= 0.1.0 | >= v0.14.0 | >= 2.1 |
+|  < 0.1.0 | >= v0.12.0 | >= 1.9 |
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ $ gem install fluent-plugin-memcached
 
 ## Usage
 
-In your Fluentd configuration, use `type memcached`.  
+### For v0.12 style configuration
+
+In your Fluentd configuration, use `type memcached`.
 Default values would look like this:
 
 ```
@@ -42,6 +44,56 @@ To store values as json, like this:
   port 11211
   value_format json
   param_names param1,param2
+</match>
+```
+
+### For v0.14 style configuration
+
+When using v0.14 style configuration, you can choose three different type of buffer behavior:
+
+#### Simple Buffered Output
+
+```
+<match dummy>
+  type memcached
+  host localhost
+  port 11211
+  increment false
+  # value_separater " "
+  <buffer>
+    @type memory
+  </buffer>
+</match>
+```
+
+#### Tag Separated Buffered Output
+
+```
+<match dummy>
+  type memcached
+  host localhost
+  port 11211
+  increment false
+  # value_separater " "
+  <buffer tag>
+    @type memory
+  </buffer>
+</match>
+```
+
+#### Time Sliced Buffered Output
+
+```
+<match dummy>
+  type memcached
+  host localhost
+  port 11211
+  increment false
+  # value_separater " "
+  <buffer tag, time>
+    @type memory
+    timekey 3600 # for 1 hour
+  </buffer>
 </match>
 ```
 


### PR DESCRIPTION
* Add requirements section for some pitfall.
  * v0.14 plugin API does not have backward compatibility
* Add buffer configuration example
* Use v1 config syntax